### PR TITLE
Add sub-issues API

### DIFF
--- a/repos/{owner}/{repo}/issues/{issue_number}/sub_issues/get.md
+++ b/repos/{owner}/{repo}/issues/{issue_number}/sub_issues/get.md
@@ -1,0 +1,28 @@
+# List sub-issues
+
+`GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues`
+
+[API method documentation](https://docs.github.com/rest/issues/sub-issues#list-sub-issues)
+
+## All Parameters for "List sub-issues"
+
+### Path Parameters
+
+- `owner` (string, required): The account owner of the repository. The name is not case sensitive.
+- `repo` (string, required): The name of the repository without the `.git` extension. The name is not case sensitive.
+- `issue_number` (integer, required): The number that identifies the issue.
+### Query Parameters
+
+- `per_page` (integer): The number of results per page (max 100). For more information, see "[Using pagination in the REST API](https://docs.github.com/rest/using-the-rest-api/using-pagination-in-the-rest-api)."
+- `page` (integer): The page number of the results to fetch. For more information, see "[Using pagination in the REST API](https://docs.github.com/rest/using-the-rest-api/using-pagination-in-the-rest-api)."
+
+## Operation Description
+
+You can use the REST API to list the sub-issues on an issue.
+
+This endpoint supports the following custom media types. For more information, see "[Media types](https://docs.github.com/rest/using-the-rest-api/getting-started-with-the-rest-api#media-types)."
+
+- **`application/vnd.github.raw+json`**: Returns the raw markdown body. Response will include `body`. This is the default if you do not pass any specific media type.
+- **`application/vnd.github.text+json`**: Returns a text only representation of the markdown body. Response will include `body_text`.
+- **`application/vnd.github.html+json`**: Returns HTML rendered from the body's markdown. Response will include `body_html`.
+- **`application/vnd.github.full+json`**: Returns raw, text, and HTML representations. Response will include `body`, `body_text`, and `body_html`.


### PR DESCRIPTION
- Part of https://github.com/github/memex/issues/19026
- Related to https://github.com/github/copilot-api/pull/8898

Adding a file for the sub-issues API generated using [rest-api-docs-md-generator](https://github.com/github/rest-api-docs-md-generator)